### PR TITLE
Update GetByteSize() caller for: Make CompilerType::getBitSize() / getByteSize() return an optional result. NFC

### DIFF
--- a/source/Plugins/ExpressionParser/Rust/RustParse.cpp
+++ b/source/Plugins/ExpressionParser/Rust/RustParse.cpp
@@ -89,7 +89,7 @@ CreateValueInMemory(ExecutionContext &exe_ctx, CompilerType type, Status &error)
   }
 
   Process *proc = exe_ctx.GetProcessPtr();
-  uint64_t size = type.GetByteSize(proc);
+  uint64_t size = type.GetByteSize(proc).getValueOr(0);
   addr_t addr = proc->AllocateMemory(size,
                                      lldb::ePermissionsWritable | lldb::ePermissionsReadable,
                                      error);


### PR DESCRIPTION
Update for:
        commit 2680b529d48d1c3dc28bde73afbba2aaada074fd
        Make CompilerType::getBitSize() / getByteSize() return an optional result. NFC

I did not check if Rust can have types of 0 size or not. But they would not work before anyway.
