### PR TITLE
Update RustPath::FindDecl for: [SymbolFile] Remove the SymbolContext parameter from FindNamespace.

### DIFF
--- a/source/Plugins/ExpressionParser/Rust/RustParse.cpp
+++ b/source/Plugins/ExpressionParser/Rust/RustParse.cpp
@@ -518,10 +518,9 @@ RustPath::FindDecl(ExecutionContext &exe_ctx, Status &error,
         return true;
       }
 
-      SymbolContext null_sc;
       CompilerDeclContext found_ns;
       for (const ConstString &ns_name : fullname) {
-        found_ns = symbol_file->FindNamespace(null_sc, ns_name, &found_ns);
+        found_ns = symbol_file->FindNamespace(ns_name, &found_ns);
         if (!found_ns) {
           break;
         }


### PR DESCRIPTION
Update for:
        commit 1fb14a530717b350db9430cd572eb250c50c031b
        [SymbolFile] Remove the SymbolContext parameter from FindNamespace.